### PR TITLE
fix(container): make the image deployable on a managed platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,23 @@ RUN pip install --no-cache-dir .
 RUN groupadd --gid 10001 aidumem \
  && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin aidumem \
  && mkdir -p /app/data /app/logs \
- && chown -R aidumem:aidumem /app/data /app/logs
+ && chown -R aidumem:0 /app/data /app/logs \
+ && chmod -R g=u /app/data /app/logs
 
 # ★ 只交接 data/ 与 logs/，**不** chown 整个 /app：
 #   代码目录保持 root 属主、进程只读，等于免费拿到「运行期改不了自己代码」。
 #   代价是 __pycache__ 写不进 —— 只是每次启动多花几百毫秒重新编译字节码，
 #   不影响功能（Python 写不进 pycache 时静默降级，不报错）。
+#
+# ★ 组给 0、并给组写权限，不是随手放宽 —— 容器 PaaS（Kubernetes 的
+#   runAsUser、OpenShift、Dockhold 等托管平台）**不理会镜像里的 USER**，
+#   而是分配一个事先不知道的 uid 把进程跑起来，惯例是把它放进 gid 0。
+#   目录若是 10001:10001 0755，那个 uid 就只读，症状是启动时
+#   `sqlite3.OperationalError: unable to open database file`，
+#   且抛在 **import 期**（ducky/salience/__init__.py 建表），
+#   日志还没起来，看不出是权限问题。
+#   本机复现：docker run --user 12345:0 <image> python -c "import ducky"
+#   上面那条取舍不受影响：uid 仍是 10001，/app 仍是 root 属主。
 USER aidumem
 
 EXPOSE 8767

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,12 @@ EXPOSE 8767
 # 需要对外暴露时，请通过 docker run -e AIDUMEM_HOST=0.0.0.0 覆盖，
 # 并务必同时设置 AIDUMEM_API_TOKEN 与 AIDUMEM_UI_PASSWORD，前置 TLS 反代。
 ENV AIDUMEM_HOST="127.0.0.1"
-ENV AIDUMEM_API_PORT="8767"
+
+# ★ 这里**不设** AIDUMEM_API_PORT。镜像里设了它，`docker run` 传进来的
+#   `PORT` 就永远轮不到 —— 端口链是 AIDUMEM_API_PORT → MEM0_API_PORT → PORT，
+#   镜像 ENV 让第一环恒非空，容器 PaaS 那一环成了死代码。
+#   不设的默认值仍是 8767（api_server.main() 的默认），`docker run` 行为不变；
+#   docker-compose.yml 里那条显式的 AIDUMEM_API_PORT=8767 也照旧生效。
 
 # ★ v20.2.5（外审 F-01）：**显式交接运行目录**。
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,17 @@ ENV AIDUMEM_DATA_DIR="/app/data"
 ENV AIDUMEM_LOG_DIR="/app/logs"
 ENV AIDUMEM_CONFIG_FILE="/app/mem0_config_local.json"
 
+# ★ HOME 必须指向一个**可写**目录（与 deploy/aidumem-api.service 的
+#   `StateDirectory` + `Environment=HOME=` 是同一件事，那边已经修过）。
+#   `useradd --no-create-home` 之后 $HOME 指向不存在的 /home/aidumem，
+#   而 mem0 SDK 在 import 期就要往 $HOME 下写缓存。缺这一行的表现，
+#   与生产上那次一模一样：**带着绿灯失能** ——
+#       /health   → status=ok
+#       但 degraded 里有 vector_backend，向量检索静默零召回
+#       日志里只有一行 `mem0 SDK 加载失败: [Errno 13] Permission denied`
+#   容器上还多一种走法：托管平台换了 uid 时 $HOME 变成 /，报的是 '/.mem0'。
+#   本机复现：docker run <image> python -c "import mem0"
+
+ENV HOME="/app/data"
+
 CMD ["aidumem"]

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ v14 Aegis 起，所有与部署环境相关的可变项都通过环境变量注�
 | `AIDUMEM_DEFAULT_AGENT_ID` | `local` | 联邦默认 agent_id |
 | `AIDUMEM_LEGACY_USER_IDS` | 空 | 历史 user_id 映射（逗号分隔，如 `admin,user`），映射后老数据才能被召回。v19.1.1 起不再硬编码 `admin/user` 映射 |
 | `AIDUMEM_API_TOKEN` | 空 | REST API 访问令牌；设置后所有接口强制 `Authorization: Bearer`。本地/回环可不设，对外部署必设 |
-| `AIDUMEM_API_PORT` | `8767` | API + 控制台监听端口 |
+| `AIDUMEM_API_PORT` | `8767` | API + 控制台监听端口。未设时回落 `MEM0_API_PORT`，再回落 `PORT`（容器 PaaS 在运行时注入端口用的标准名） |
 | `AIDUMEM_ENTITY_KEYWORDS` | 空 | 相关性闸门的自定义实体词表，`\|` 分隔 |
 | `UI_DIR` | `<repo>/frontend` | 控制台静态文件目录（不存在则仅 API 模式） |
 | `AIDUMEM_URL` | `http://127.0.0.1:8767` | 宿主插件 / shell hook 访问服务的地址 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -301,7 +301,7 @@ Since v14 Aegis, all deployment-specific settings are injected via environment v
 | `AIDUMEM_ENTITY_KEYWORDS` | empty | Custom entity keywords for relevance gate, `\|` separated |
 | `AIDUMEM_LEGACY_USER_IDS` | empty | Historical `user_id` aliases (comma-separated, e.g. `admin,user`); without the mapping, older rows cannot be recalled. The hardcoded `admin`/`user` mapping was removed in v19.1.1 |
 | `AIDUMEM_API_TOKEN` | empty | REST API token. Once set, **every** endpoint requires `Authorization: Bearer`. Optional on loopback; **mandatory for any deployment reachable from outside** |
-| `AIDUMEM_API_PORT` | `8767` | API + console listen port |
+| `AIDUMEM_API_PORT` | `8767` | API + console listen port. Falls back to `MEM0_API_PORT`, then to `PORT` (the standard name container PaaS platforms use to inject a runtime port) |
 | `AIDUMEM_CONFIG_READONLY` | `0` | `1` makes the console's config endpoints read-only |
 | `UI_DIR` | `<repo>/frontend` | Console static files (API-only mode if absent) |
 | `AIDUMEM_URL` | `http://127.0.0.1:8767` | Hermes plugin / hook service URL |

--- a/api_server.py
+++ b/api_server.py
@@ -943,6 +943,13 @@ def main():
     _port_name, _port_raw = "AIDUMEM_API_PORT", os.environ.get("AIDUMEM_API_PORT")
     if not _port_raw:
         _port_name, _port_raw = "MEM0_API_PORT", os.environ.get("MEM0_API_PORT")
+    if not _port_raw:
+        # 容器 PaaS（Dockhold / Heroku / Railway / Render / Fly / Cloud Run 等）在**运行时**
+        # 才分配端口，且只通过 `PORT` 传入。部署方事先不知道值，写不进
+        # AIDUMEM_API_PORT —— 于是服务监听 8767、平台往另一个端口转发，
+        # 表现为「进程健康、外面 502」，日志里一句异常都没有。
+        # 排在两个专名之后：本地与 compose 部署的行为完全不变。
+        _port_name, _port_raw = "PORT", os.environ.get("PORT")
     port = _int_env(_port_name, 8767, minimum=1, maximum=65535, raw=_port_raw)
     if not _api_token():
         logger.warning(

--- a/tests/test_v20_p38_least_privilege.py
+++ b/tests/test_v20_p38_least_privilege.py
@@ -340,6 +340,21 @@ def test_dockerfile_hands_over_only_the_writable_dirs():
     assert re.search(r"chown[^\n]*/app/data", df), "Dockerfile 没有把 /app/data 交给运行账号"
     assert re.search(r"chown[^\n]*/app/logs", df), "Dockerfile 没有把 /app/logs 交给运行账号"
 
+    # 交出可写目录还不够 —— $HOME 得**指到**其中一个。
+    # 这一条是 test_api_unit_gives_the_service_a_writable_home 的容器侧对偶：
+    # 那边生产实测踩过（mem0 SDK import 期写 $HOME，缺了就带着绿灯失能），
+    # systemd 一侧修了并立了守卫，Dockerfile 一侧同样的洞没人看着。
+    home = re.findall(r'^\s*ENV\s+HOME=[\"\']?(\S+?)[\"\']?\s*$', df, re.M)
+    assert home, (
+        "Dockerfile 没有 ENV HOME —— useradd --no-create-home 之后 $HOME 指向"
+        "不存在的目录，mem0 SDK 在 import 期写它，失败后服务照常起、/health 照常绿，"
+        "只有向量检索静默零召回。"
+    )
+    assert home[-1] in ("/app/data", "/app/logs"), (
+        f"ENV HOME={home[-1]} 不是交给运行账号的那两个目录之一 —— "
+        "指到只读目录等于没设。"
+    )
+
 
 def test_compose_drops_capabilities_and_blocks_privilege_gain():
     """compose 侧再补一道：cap_drop ALL + no-new-privileges。


### PR DESCRIPTION
You asked for this on #6. Three commits, separable, take any of them alone.
Each one is a `docker run` you can paste.

**1. Fall back to `PORT`.**

Platforms assign the port at runtime and pass it in `PORT`, so the operator
cannot put it in `AIDUMEM_API_PORT`. Without this the service listens on 8767,
the platform routes elsewhere, and you get a healthy process behind a 502 with
nothing in the log.

Chain is now `AIDUMEM_API_PORT` -> `MEM0_API_PORT` -> `PORT` -> 8767. `PORT` is
last, so local and compose are unchanged. The Dockerfile had to stop setting
`ENV AIDUMEM_API_PORT="8767"`, which kept the first link non-empty and made the
new one dead code. `docker run` still gets 8767 from the default in `main()`.

**2. Let an arbitrary uid write `/app/data` and `/app/logs`.**

```
docker run --user 12345:0 <image> python -c "import ducky"
sqlite3.OperationalError: unable to open database file
```

Platforms ignore the image `USER` and run as a uid they pick, conventionally in
gid 0. Your dirs are `10001:10001` mode 0755, so that uid is read-only. It
throws at import, from `ducky/salience/__init__.py`, before logging exists, and
never mentions permissions.

Fixed with the gid-0 pattern. Checked three ways so the group bit is doing the
work: `10001:10001` ok before and after, `12345:0` crash then ok, `12345:12345`
crash both times. Your uid stays 10001 and `/app` stays root-owned.

**3. Give the container a writable `HOME`.**

```
docker run <image> python -c "import mem0"
PermissionError: [Errno 13] Permission denied: '/home/aidumem'
```

You fixed this once already, in `deploy/aidumem-api.service`, and
`test_api_unit_gives_the_service_a_writable_home` holds it there. The Dockerfile
has the same hole with nothing watching it. `useradd --no-create-home`, so
`$HOME` is a directory that does not exist and the mem0 SDK writes under it at
import. Service starts, `/health` says ok, vector recall is quietly gone. Your
docstring already named it: 带着绿灯失能.

`ENV HOME=/app/data`. The assertion went into the existing
`test_dockerfile_hands_over_only_the_writable_dirs`, not a new file, so the
README case totals do not move. It fails without the `ENV` line and passes with
it.

**Checks.**

`pytest tests/ -q` in a `python:3.12-slim` container: 1682 passed, 40 skipped,
identical to `main` in the same container, same 6 failures from things the
container lacks (crontab, git config, ruff). `acceptance_check.sh` matches too.

Deployed the branch: came up with no variables set and logged
`Uvicorn running on 0.0.0.0:8080`, the injected `PORT`. The unpatched tree
crashed with the SQLite error above.

**Left out on purpose.** Nothing for the data directory: `AIDUMEM_DATA_DIR`
already overrides the image `ENV` at runtime, so it needs no code. And no new
test file, for the README count reason above.

The Dockhold guide you offered to feature is written. It goes out after this
merges, not before: a deploy link builds whatever is at the URL it points at,
so today it would send people into the crash in commit 2. Tell me the shape you
want and I will match it, a page here, a section you paste, or a link you own.

All three are standard container conventions, so they are worth the same on
Heroku, Railway, Render, Fly, Cloud Run and Kubernetes.
